### PR TITLE
Tweaks to the Dropwizard example

### DIFF
--- a/dropwizard/nologging.yml
+++ b/dropwizard/nologging.yml
@@ -4,7 +4,6 @@ server:
     - type: http
       port: 8080
       bindHost: 127.0.0.1 # only bind to loopback
-      inheritChannel: false
       headerCacheSize: 512 bytes
       outputBufferSize: 32KiB
       maxRequestHeaderSize: 8KiB
@@ -14,8 +13,6 @@ server:
       minBufferPoolSize: 64 bytes
       bufferPoolIncrement: 1KiB
       maxBufferPoolSize: 64KiB
-      acceptorThreads: 1
-      selectorThreads: 2
       acceptQueueSize: 1024
       reuseAddress: true
       soLingerTime: 345s
@@ -26,10 +23,10 @@ server:
     appenders: []
 
 logging:
-  level: WARN 
+  level: WARN
   appenders:
     - type: console
-      threshold: WARN 
+      threshold: WARN
       timeZone: UTC
       target: stdout
       logFormat: # TODO

--- a/dropwizard/src/main/java/com/mycompany/HelloWorldApplication.java
+++ b/dropwizard/src/main/java/com/mycompany/HelloWorldApplication.java
@@ -22,7 +22,7 @@ public class HelloWorldApplication extends Application<HelloWorldConfiguration> 
     @Override
     public void run(HelloWorldConfiguration configuration,
                     Environment environment) {
-        environment.jersey().register(new HelloWorldResource());        // nothing to do yet
+        environment.jersey().register(HelloWorldResource.class);        // nothing to do yet
     }
 
 }

--- a/dropwizard/src/main/java/com/mycompany/HelloWorldResource.java
+++ b/dropwizard/src/main/java/com/mycompany/HelloWorldResource.java
@@ -1,13 +1,14 @@
 package com.mycompany;
 
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.inject.Singleton;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
+@Singleton
 public class HelloWorldResource {
     @GET
     public String sayHello() {


### PR DESCRIPTION
Mostly for my own comparison. I wanted to see how Dropwizard performs with a more realistic example which included the overhead of jersey's DI (HK2).

Also removed setting the acceptor/selector thread settings and letting it use the default. Controlling this variable makes sense, but I did not notice other benchmarks explicitly setting these values. 

Before (after 3 warmup runs)
```
proxy:microservices-framework-benchmark david$ wrk -t4 -c128 -d30s http://localhost:8080 -s pipeline.lua --latency -- / 16
Running 30s test @ http://localhost:8080
  4 threads and 128 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   117.38ms  142.15ms   1.45s    85.50%
    Req/Sec     7.81k     3.42k   27.46k    75.75%
  Latency Distribution
     50%   58.06ms
     75%  154.14ms
     90%  321.41ms
     99%  639.80ms
  910336 requests in 30.03s, 86.82MB read
Requests/sec:  30316.34
Transfer/sec:      2.89MB
```

After (after 3 warmup runs)
```
proxy:microservices-framework-benchmark david$ wrk -t4 -c100 -d30s http://localhost:8080
Running 30s test @ http://localhost:8080
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     7.68ms   16.03ms 280.68ms   91.67%
    Req/Sec     5.96k     2.75k   20.38k    69.82%
  702814 requests in 30.07s, 67.03MB read
Requests/sec:  23369.43
Transfer/sec:      2.23MB
```